### PR TITLE
Allow more pytest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pytest>=8.3.3",
+  "pytest>=8.2.0",
   "tomli>=2.0.1; python_version<'3.11'",
 ]
 optional-dependencies.testing = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pytest>=8.2.0",
+  "pytest>=8.2",
   "tomli>=2.0.1; python_version<'3.11'",
 ]
 optional-dependencies.testing = [


### PR DESCRIPTION
I think that this library should not force users of it to update pytest to almost the latest version unless there is an incompatibility reason for it. This MR relaxes a bit the required version to what I think was the latest big change on pytest.