### PR TITLE
✨ feat(config): support [tool.pytest] in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # pytest-env
 
 [![PyPI](https://img.shields.io/pypi/v/pytest-env?style=flat-square)](https://pypi.org/project/pytest-env/)
-[![Supported Python
-versions](https://img.shields.io/pypi/pyversions/pytest-env.svg)](https://pypi.org/project/pytest-env/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/pytest-env.svg)](https://pypi.org/project/pytest-env/)
 [![check](https://github.com/pytest-dev/pytest-env/actions/workflows/check.yaml/badge.svg)](https://github.com/pytest-dev/pytest-env/actions/workflows/check.yaml)
 [![Downloads](https://static.pepy.tech/badge/pytest-env/month)](https://pepy.tech/project/pytest-env)
 
-This is a `pytest` plugin that enables you to set environment variables in `pytest.ini`, `pyproject.toml`, `pytest.toml` or `.pytest.toml` files.
+This is a `pytest` plugin that enables you to set environment variables in `pytest.ini`, `pyproject.toml`, `pytest.toml`
+or `.pytest.toml` files.
 
 ## Installation
 
@@ -20,10 +20,8 @@ pip install pytest-env
 
 ### Native form in `pyproject.toml`, `pytest.toml` and `.pytest.toml`
 
-> [!NOTE]
-> `pytest.toml` and `.pytest.toml` is only supported on Pytest 9.0+.
-
-Native form takes precedence over the `pytest.ini` form. `pytest.toml` takes precedence over `.pytest.toml`, and that takes precedence over `pyproject.toml`.
+Native form takes precedence over the `pytest.ini` form. `pytest.toml` takes precedence over `.pytest.toml`, and that
+takes precedence over `pyproject.toml`.
 
 In `pyproject.toml`:
 
@@ -31,8 +29,8 @@ In `pyproject.toml`:
 [tool.pytest_env]
 HOME = "~/tmp"
 RUN_ENV = 1
-TRANSFORMED = {value = "{USER}/alpha", transform = true}
-SKIP_IF_SET = {value = "on", skip_if_set = true}
+TRANSFORMED = { value = "{USER}/alpha", transform = true }
+SKIP_IF_SET = { value = "on", skip_if_set = true }
 ```
 
 In `pytest.toml` (or `.pytest.toml`):
@@ -41,11 +39,12 @@ In `pytest.toml` (or `.pytest.toml`):
 [pytest_env]
 HOME = "~/tmp"
 RUN_ENV = 1
-TRANSFORMED = {value = "{USER}/alpha", transform = true}
-SKIP_IF_SET = {value = "on", skip_if_set = true}
+TRANSFORMED = { value = "{USER}/alpha", transform = true }
+SKIP_IF_SET = { value = "on", skip_if_set = true }
 ```
 
-The `tool.pytest_env` (`pytest_env` in `pytest.toml` and `.pytest.toml`) tables keys are the environment variables keys to set. The right hand side of the assignment:
+The `tool.pytest_env` (`pytest_env` in `pytest.toml` and `.pytest.toml`) tables keys are the environment variables keys
+to set. The right hand side of the assignment:
 
 - if an inline table you can set options via the `transform` or `skip_if_set` keys, while the `value` key holds the
   value to set (or transform before setting). For transformation the variables you can use is other environment
@@ -67,16 +66,23 @@ env =
 Or with `pyproject.toml`:
 
 ```toml
-[tool.pytest.ini_options]
+[tool.pytest]
 env = [
-    "HOME=~/tmp",
-    "RUN_ENV=test",
+  "HOME=~/tmp",
+  "RUN_ENV=test",
 ]
 ```
 
 ### Only set if not already set
 
-You can use `D:` (default) as prefix if you don't want to override existing environment variables:
+Use `skip_if_set = true` in the native TOML form, or the `D:` (default) prefix in INI form, to only set the variable
+when it is not already defined in the environment:
+
+```toml
+[pytest_env]
+HOME = { value = "~/tmp", skip_if_set = true }
+RUN_ENV = { value = "test", skip_if_set = true }
+```
 
 ```ini
 [pytest]
@@ -87,8 +93,13 @@ env =
 
 ### Transformation
 
-You can use existing environment variables using a python-like format, these environment variables will be expended
-before setting the environment variable:
+You can reference existing environment variables using a python-like format. Use `transform = true` in the native TOML
+form, or omit the `R:` prefix in INI form (transformation is the default in INI):
+
+```toml
+[pytest_env]
+RUN_PATH = { value = "/run/path/{USER}", transform = true }
+```
 
 ```ini
 [pytest]
@@ -96,8 +107,14 @@ env =
     RUN_PATH=/run/path/{USER}
 ```
 
-You can apply the `R:` prefix to keep the raw value and skip this transformation step (can combine with the `D:` flag,
-order is not important):
+To keep the raw value and skip transformation, omit `transform` (or set it to `false`) in TOML, or apply the `R:` prefix
+in INI (can combine with `D:`/`skip_if_set`, order is not important):
+
+```toml
+[pytest_env]
+RUN_PATH = { value = "/run/path/{USER}" }
+RUN_PATH_IF_NOT_SET = { value = "/run/path/{USER}", skip_if_set = true }
+```
 
 ```ini
 [pytest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pytest>=8.4.2",
+  "pytest>=9",
   "tomli>=2.2.1; python_version<'3.11'",
 ]
 optional-dependencies.testing = [

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -141,6 +141,15 @@ def test_env_via_pytest(
         ),
         pytest.param(
             {},
+            '[tool.pytest]\nenv = ["MAGIC=toml", "MAGIC_2=toml2"]',
+            "",
+            "",
+            {"MAGIC": "toml", "MAGIC_2": "toml2"},
+            None,
+            id="pyproject toml via tool.pytest",
+        ),
+        pytest.param(
+            {},
             '[tool.pytest_env]\nMAGIC = 1\nMAGIC_2 = "toml2"',
             "",
             "",


### PR DESCRIPTION
Pytest 9.0 introduced `[tool.pytest]` as the native TOML alternative to `[tool.pytest.ini_options]` in `pyproject.toml`. While pytest-env already handled this transparently through `getini()`, the documentation only showed the old `[tool.pytest.ini_options]` form, leaving users unaware they could use the cleaner syntax.

This bumps the minimum pytest requirement to `>=9` and updates the README to show `[tool.pytest]` as the documented approach. Since pytest 9.0 is now the baseline, the conditional note about `pytest.toml`/`.pytest.toml` requiring 9.0+ is also removed.

Fixes #183