### PR TITLE
🐛 fix(config): use inipath for TOML file discovery

### DIFF
--- a/src/pytest_env/plugin.py
+++ b/src/pytest_env/plugin.py
@@ -66,7 +66,8 @@ def _parse_toml_config(config: dict[str, Any]) -> Generator[Entry, None, None]:
 
 def _load_values(early_config: pytest.Config) -> Iterator[Entry]:
     has_toml = False
-    for path in chain.from_iterable([[early_config.rootpath], early_config.rootpath.parents]):
+    start_path = early_config.inipath.parent if early_config.inipath is not None else early_config.rootpath
+    for path in chain.from_iterable([[start_path], start_path.parents]):
         for pytest_toml_name in ("pytest.toml", ".pytest.toml", "pyproject.toml"):
             pytest_toml_file = path / pytest_toml_name
             if pytest_toml_file.exists():


### PR DESCRIPTION
When a subdirectory has its own `pytest.toml` with `[pytest_env]`, the parent's `pyproject.toml` is incorrectly picked up first. This happens because the TOML file walk starts from `early_config.rootpath`, which always points to the project root regardless of which config file pytest actually resolved. 🔍 For example, running pytest from `tests_integration/` with its own `pytest.toml` still loads env vars from the root `pyproject.toml`.

The fix changes the walk starting point to `early_config.inipath.parent` — the directory containing the config file pytest resolved. This way a subdirectory's `pytest.toml` with `[pytest_env]` is found first, matching how pytest itself resolves configuration. When `inipath` is `None` (no config file found), the behavior falls back to `rootpath`, preserving existing behavior.

📝 The README has also been restructured for clarity: TOML and INI configuration are now separate sections with reference tables for inline-table keys and prefix flags, precedence rules and file discovery are documented explicitly, and feature examples are consolidated with side-by-side TOML/INI comparisons.

Fixes #75