### PR TITLE
✨ feat(plugin): add .env file loading support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,14 +13,14 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        additional_dependencies: ["tomli>=2.2.1"]
+        additional_dependencies: ["tomli>=2.4"]
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: "1.7.1"
     hooks:
       - id: tox-ini-fmt
         args: ["-p", "fix"]
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.15.0"
+    rev: "v2.15.2"
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: prettier
         additional_dependencies:
-          - prettier@3.6.2
+          - prettier@3.8.1
           - "@prettier/plugin-xml@3.4.2"
   - repo: meta
     hooks:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://static.pepy.tech/badge/pytest-env/month)](https://pepy.tech/project/pytest-env)
 
 A `pytest` plugin that sets environment variables from `pyproject.toml`, `pytest.toml`, `.pytest.toml`, or `pytest.ini`
-configuration files.
+configuration files. It can also load variables from `.env` files.
 
 ## Installation
 
@@ -103,6 +103,43 @@ project/
 Running `pytest tests_integration/` uses `DB_HOST = "test-db"` from the subdirectory.
 
 If no TOML file with a `pytest_env` section is found, the plugin falls back to the INI-style `env` key.
+
+### Loading `.env` files
+
+Use `env_files` to load variables from `.env` files. Files are loaded before inline `env` entries, so inline config
+takes precedence. Missing files are silently skipped. Paths are relative to the project root.
+
+```toml
+# pyproject.toml
+[tool.pytest_env]
+env_files = [".env", ".env.test"]
+API_KEY = "override_value"
+```
+
+```toml
+# pytest.toml or .pytest.toml
+[pytest_env]
+env_files = [".env"]
+```
+
+```ini
+# pytest.ini
+[pytest]
+env_files =
+    .env
+    .env.test
+```
+
+Files are parsed by [python-dotenv](https://github.com/theskumar/python-dotenv), supporting `KEY=VALUE` lines, `#`
+comments, `export` prefix, quoted values (with escape sequences in double quotes), and `${VAR:-default}` expansion:
+
+```shell
+# .env
+DATABASE_URL=postgres://localhost/mydb
+export SECRET_KEY='my-secret-key'
+DEBUG="true"
+MESSAGE="hello\nworld"
+```
 
 ### Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs>=0.5",
-  "hatchling>=1.27",
+  "hatchling>=1.28",
 ]
 
 [project]
@@ -36,12 +36,13 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "pytest>=9",
-  "tomli>=2.2.1; python_version<'3.11'",
+  "pytest>=9.0.2",
+  "python-dotenv>=1.2.1",
+  "tomli>=2.4; python_version<'3.11'",
 ]
 optional-dependencies.testing = [
   "covdefaults>=2.3",
-  "coverage>=7.10.7",
+  "coverage>=7.13.4",
   "pytest-mock>=3.15.1",
 ]
 urls.Homepage = "https://github.com/pytest-dev/pytest-env"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
-    tox>=4.30.3
-    tox-uv>=1.28
+    tox>=4.34.1
+    tox-uv>=1.29
 env_list =
     fix
     3.14
@@ -37,7 +37,7 @@ commands =
 description = run static analysis and style check using flake8
 skip_install = true
 deps =
-    pre-commit-uv>=4.1.5
+    pre-commit-uv>=4.2
 pass_env =
     HOMEPATH
     PROGRAMDATA
@@ -47,7 +47,7 @@ commands =
 [testenv:type]
 description = run type check on code base
 deps =
-    mypy==1.18.2
+    mypy==1.19.1
 commands =
     mypy --strict src
     mypy --strict tests
@@ -58,7 +58,7 @@ skip_install = true
 deps =
     check-wheel-contents>=0.6.3
     twine>=6.2
-    uv>=0.8.22
+    uv>=0.10.2
 commands =
     uv build --sdist --wheel --out-dir {env_tmp_dir} .
     twine check {env_tmp_dir}{/}*


### PR DESCRIPTION
The [pytest-dotenv](https://github.com/quiqua/pytest-dotenv) plugin is no longer maintained, leaving users without
a supported way to load `.env` files during test runs. This adds native `.env` file support directly to pytest-env,
so users can drop the extra dependency and keep their workflow intact. Closes #184.

A new `env_files` config option accepts a list of `.env` file paths, resolved relative to the project root. 📂 The
parser handles `KEY=VALUE` lines, `#` comments, blank lines, optional single/double quoting, and whitespace around
keys and values. Missing files are silently skipped, following the dotenv convention that allows committing config
referencing `.env` while the file only exists locally.

`.env` files are loaded **before** inline `env` entries, so inline config always takes precedence. ✨ This means
existing flags like `skip_if_set` and `transform` work naturally with values loaded from `.env` files. The feature
works across all config formats — native TOML (`env_files = [".env"]`), and INI linelist (`env_files = .env`).