### PR TITLE
🔧 build(type): migrate from mypy to ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,5 @@ report.show_missing = true
 html.show_contexts = true
 html.skip_covered = false
 
-[tool.mypy]
-python_version = "3.11"
-show_error_codes = true
-strict = true
+[tool.ty]
+environment.python-version = "3.14"

--- a/tox.ini
+++ b/tox.ini
@@ -47,10 +47,9 @@ commands =
 [testenv:type]
 description = run type check on code base
 deps =
-    mypy==1.19.1
+    ty==0.0.16
 commands =
-    mypy --strict src
-    mypy --strict tests
+    ty check --output-format concise --error-on-warning .
 
 [testenv:pkg_meta]
 description = check that the long description is valid


### PR DESCRIPTION
mypy is being deprecated in favor of `ty`, which provides significantly faster type checking with better performance characteristics and more accurate type inference. ⚡

The migration replaces `mypy==1.19.1` with `ty==0.0.16` in the type checking tox environment. The command changes from running mypy separately on `src` and `tests` to a single `ty check` invocation with concise output format and warnings treated as errors.

Configured ty to target Python 3.14 specifically to align with the type checking environment and avoid false positives from conditional imports like `tomli` that only apply to older Python versions. 🐍