### PR TITLE
✨ feat(plugin): add --pytest-env-verbose for debugging env assignments

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,11 +7,9 @@ on:
   pull_request:
   schedule:
     - cron: "0 8 * * *"
-
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,8 @@ name: Release to PyPI
 on:
   push:
     tags: ["*"]
-
 env:
   dists-artifact-name: python-package-distributions
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +24,6 @@ jobs:
         with:
           name: ${{ env.dists-artifact-name }}
           path: dist/*
-
   release:
     needs:
       - build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,18 @@ repos:
       - id: ruff-format
       - id: ruff
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.8.1"
+  - repo: https://github.com/hukkin/mdformat
+    rev: "1.0.0"
     hooks:
-      - id: prettier
+      - id: mdformat
         additional_dependencies:
-          - prettier@3.8.1
-          - "@prettier/plugin-xml@3.4.2"
+          - mdformat-config>=0.2.1
+          - mdformat-gfm>=1
+          - mdformat-toc>=0.5
+  - repo: https://github.com/google/yamlfmt
+    rev: "v0.21.0"
+    hooks:
+      - id: yamlfmt
   - repo: meta
     hooks:
       - id: check-hooks-apply

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+from unittest import mock
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_verbose_shows_set_from_ini(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pytest.ini").write_text("[pytest]\nenv = MAGIC=alpha", encoding="utf-8")
+
+    new_env = {
+        "_TEST_ENV": repr({"MAGIC": "alpha"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*pytest-env:*", "*SET*MAGIC=alpha*"])
+
+
+def test_verbose_shows_set_from_toml(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pyproject.toml").write_text(
+        '[tool.pytest_env]\nMY_VAR = "hello"',
+        encoding="utf-8",
+    )
+
+    new_env = {
+        "_TEST_ENV": repr({"MY_VAR": "hello"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*pytest-env:*", "*SET*MY_VAR=hello*(from*pyproject.toml*"])
+
+
+def test_verbose_shows_set_from_env_file(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / ".env").write_text("FROM_FILE=value", encoding="utf-8")
+    (pytester.path / "pyproject.toml").write_text(
+        '[tool.pytest_env]\nenv_files = [".env"]',
+        encoding="utf-8",
+    )
+
+    new_env = {
+        "_TEST_ENV": repr({"FROM_FILE": "value"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*SET*FROM_FILE=value*(from*.env*"])
+
+
+def test_verbose_shows_skip(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pytest.ini").write_text("[pytest]\nenv = D:EXISTING=new", encoding="utf-8")
+
+    new_env = {
+        "EXISTING": "original",
+        "_TEST_ENV": repr({"EXISTING": "original"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*SKIP*EXISTING=original*"])
+
+
+def test_verbose_shows_unset(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pytest.ini").write_text("[pytest]\nenv = U:TO_REMOVE", encoding="utf-8")
+
+    new_env = {
+        "TO_REMOVE": "gone",
+        "_TEST_ENV": repr({"TO_REMOVE": None}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*UNSET*TO_REMOVE*"])
+
+
+def test_verbose_shows_transform(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pyproject.toml").write_text(
+        dedent("""\
+            [tool.pytest_env]
+            GREETING = {value = "hello_{PLANET}", transform = true}
+        """),
+        encoding="utf-8",
+    )
+
+    new_env = {
+        "PLANET": "world",
+        "_TEST_ENV": repr({"GREETING": "hello_world"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*SET*GREETING=hello_world*"])
+
+
+def test_no_verbose_output_without_flag(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pytest.ini").write_text("[pytest]\nenv = MAGIC=alpha", encoding="utf-8")
+
+    new_env = {
+        "_TEST_ENV": repr({"MAGIC": "alpha"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest()
+
+    result.assert_outcomes(passed=1)
+    result.stdout.no_fnmatch_line("*pytest-env:*")
+
+
+def test_verbose_multiple_sources(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / ".env").write_text("FROM_FILE=file_val", encoding="utf-8")
+    (pytester.path / "pyproject.toml").write_text(
+        dedent("""\
+            [tool.pytest_env]
+            env_files = [".env"]
+            INLINE = "inline_val"
+        """),
+        encoding="utf-8",
+    )
+
+    new_env = {
+        "_TEST_ENV": repr({"FROM_FILE": "file_val", "INLINE": "inline_val"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines([
+        "*SET*FROM_FILE=file_val*(from*.env*",
+        "*SET*INLINE=inline_val*(from*pyproject.toml*",
+    ])


### PR DESCRIPTION
When multiple env files, inline config, CLI `--envfile` options, and exported variables all interact, tracking what pytest-env actually sets becomes painful. This is especially true after the recent addition of `.env` file loading and the `--envfile` CLI option, which significantly increased the number of possible sources. Closes #198.

The new `--pytest-env-verbose` flag prints every environment variable action (SET, SKIP, UNSET) along with its source file in the test session header via `pytest_report_header`, following the same pattern pytest's own `cacheprovider` uses. This avoids the `get_terminal_writer()` assertion error that occurs during early hooks and integrates cleanly with pytest's output capturing.

Example run with a `pyproject.toml` config, a `.env` file, and `TEMP_VAR` exported in the shell:

```
$ pytest --pytest-env-verbose
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
pytest-env:
  SET   API_KEY=secret123  (from /project/.env)
  SET   DEBUG=true  (from /project/.env)
  SET   DATABASE_URL=postgres://localhost/test  (from /project/pyproject.toml)
  SKIP  HOME=/Users/me  (from /project/pyproject.toml)
  UNSET TEMP_VAR  (from /project/pyproject.toml)
rootdir: /project
configfile: pyproject.toml
collected 1 item

test_it.py .                                                             [100%]
============================== 1 passed in 0.01s ===============================
```

This PR also replaces `prettier` with `mdformat` (with `mdformat-toc`, `mdformat-gfm`, and `mdformat-config` plugins) and `yamlfmt` in pre-commit, and restructures the README for readability within the existing Diataxis layout -- grouping CLI options together, consolidating small how-to guides, and adding an auto-generated table of contents.