### PR TITLE
Require envfile extra for .env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ pytest-env:
 
 ### Load variables from `.env` files
 
+Install the plugin with the `[envfile]` extra to enable `.env` file support.
+
 Specify `.env` files in your configuration:
 
 ```toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,10 @@ dynamic = [
 ]
 dependencies = [
   "pytest>=9.0.2",
-  "python-dotenv>=1.2.1",
   "tomli>=2.4; python_version<'3.11'",
+]
+optional-dependencies.envfile = [
+  "python-dotenv>=1.2.1",
 ]
 optional-dependencies.testing = [
   "covdefaults>=2.3",

--- a/tox.toml
+++ b/tox.toml
@@ -2,7 +2,7 @@
 description = "run the tests with pytest"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = [ "testing" ]
+extras = [ "testing", "envfile" ]
 pass_env = [ "DIFF_AGAINST", "PYTEST_*" ]
 set_env.COVERAGE_FILE = "{env:COVERAGE_FILE:{toxworkdir}{/}.coverage.{envname}}"
 commands = [


### PR DESCRIPTION
Follows up on #191.

I noticed a new dependency popping up in my project's dependency graph – this proposes to move envfile support behind an `[envfile]` extra.