### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,10 +10,8 @@ on:
 concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
     tags: ["*"]
 permissions:
   contents: read
-
 env:
   dists-artifact-name: python-package-distributions
 jobs:


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to workflow files
- Satisfies the `actions/missing-workflow-permissions` code scanning rule
