### PR TITLE
Fix verbose source attribution when falling back to INI env

### DIFF
--- a/src/pytest_env/plugin.py
+++ b/src/pytest_env/plugin.py
@@ -146,7 +146,9 @@ def _find_toml_config(early_config: pytest.Config) -> Path | None:
 def _config_source(early_config: pytest.Config) -> str:
     """Describe the configuration source for verbose output."""
     if toml_path := _find_toml_config(early_config):
-        return str(toml_path)
+        _, entries = _load_toml_config(toml_path)
+        if entries:
+            return str(toml_path)
     if early_config.inipath:
         return str(early_config.inipath)
     return "config"  # pragma: no cover

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -23,7 +23,31 @@ def test_verbose_shows_set_from_ini(pytester: pytest.Pytester) -> None:
         result = pytester.runpytest("--pytest-env-verbose")
 
     result.assert_outcomes(passed=1)
-    result.stdout.fnmatch_lines(["*pytest-env:*", "*SET*MAGIC=alpha*"])
+    result.stdout.fnmatch_lines(["*pytest-env:*", "*SET*MAGIC=alpha*(from*pytest.ini*"])
+
+
+def test_verbose_shows_ini_source_when_pyproject_lacks_pytest_env(pytester: pytest.Pytester) -> None:
+    (pytester.path / "test_it.py").symlink_to(Path(__file__).parent / "template.py")
+    (pytester.path / "pyproject.toml").write_text(
+        dedent("""\
+            [build-system]
+            requires = ["setuptools>=61"]
+            build-backend = "setuptools.build_meta"
+        """),
+        encoding="utf-8",
+    )
+    (pytester.path / "pytest.ini").write_text("[pytest]\nenv = MAGIC=alpha", encoding="utf-8")
+
+    new_env = {
+        "_TEST_ENV": repr({"MAGIC": "alpha"}),
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "pytest_env.plugin",
+    }
+    with mock.patch.dict(os.environ, new_env, clear=True):
+        result = pytester.runpytest("--pytest-env-verbose")
+
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*SET*MAGIC=alpha*(from*pytest.ini*"])
 
 
 def test_verbose_shows_set_from_toml(pytester: pytest.Pytester) -> None:


### PR DESCRIPTION
## What changed
- Fixed verbose source attribution so `--pytest-env-verbose` reports the INI file when `env` entries come from INI fallback.
- Added a regression test for the case where a `pyproject.toml` exists but does not contain a `pytest_env` section.
- Tightened the existing INI verbose test to assert the reported source path.

## Why
- Previously, if a TOML file was discovered but had no `pytest_env` entries, verbose output still labeled inline env assignments as coming from that TOML file.
- This made debug output misleading for projects that keep build metadata in `pyproject.toml` while configuring `env` in `pytest.ini`.

## Testing
- ✅ `. .venv/bin/activate && pytest` (71 passed)
