### PR TITLE
📦 build: move the testing extra to a dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,15 +41,17 @@ dependencies = [
   "python-dotenv>=1.2.2",
   "tomli>=2.4; python_version<'3.11'",
 ]
-optional-dependencies.testing = [
-  "covdefaults>=2.3",
-  "coverage>=7.13.4",
-  "pytest-mock>=3.15.1",
-]
 urls.Homepage = "https://github.com/pytest-dev/pytest-env"
 urls.Source = "https://github.com/pytest-dev/pytest-env"
 urls.Tracker = "https://github.com/pytest-dev/pytest-env/issues"
 entry-points.pytest11.env = "pytest_env.plugin"
+
+[dependency-groups]
+test = [
+  "covdefaults>=2.3",
+  "coverage>=7.13.4",
+  "pytest-mock>=3.15.1",
+]
 
 [tool.hatch]
 version.source = "vcs"

--- a/tox.toml
+++ b/tox.toml
@@ -18,7 +18,7 @@ skip_missing_interpreters = true
 description = "run the tests with pytest"
 package = "wheel"
 wheel_build_env = ".pkg"
-extras = [ "testing" ]
+dependency_groups = [ "test" ]
 pass_env = [ "DIFF_AGAINST", "PYTEST_*" ]
 set_env.COVERAGE_FILE = "{env:COVERAGE_FILE:{toxworkdir}{/}.coverage.{envname}}"
 commands = [
@@ -67,7 +67,7 @@ commands = [ [ "ty", "check", "--output-format", "concise", "--error-on-warning"
 [env.dev]
 description = "generate a DEV environment"
 package = "editable"
-extras = [ "testing" ]
+dependency_groups = [ "test" ]
 commands = [
   [ "uv", "pip", "tree" ],
   [ "python", "-c", "import sys; print(sys.executable)" ],


### PR DESCRIPTION
The `testing` dependencies were declared as a `[project.optional-dependencies]` extra, so they shipped in the published package metadata as an installable `pytest-env[testing]` extra even though no consumer of the plugin needs them. They exist only to develop and test the package itself, which is what PEP 735 dependency groups are for: dependency sets that stay in the source tree and never reach the wheel metadata. 📦

This moves the set into a `[dependency-groups]` `test` group and points the tox environments that used it at `dependency_groups = ["test"]` instead of `extras = ["testing"]`. The packages and their version constraints are unchanged.

The published distribution no longer advertises a `testing` extra. Local workflows that installed `pytest-env[testing]` should use the `test` dependency group (`--group test`) or the tox environments instead. Runtime dependencies stay untouched.
